### PR TITLE
(FEATURE) Add a text saying no transactions yet when no transactions were ever made

### DIFF
--- a/app/src/main/java/com/felixjhonata/simplebudgetapp/view/HomePage.kt
+++ b/app/src/main/java/com/felixjhonata/simplebudgetapp/view/HomePage.kt
@@ -26,10 +26,13 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -157,10 +160,16 @@ fun HomePage(
                 }
             } else {
                 item {
+                    val density = LocalDensity.current
+                    val screenHeight = with(density) {
+                        LocalWindowInfo.current.containerSize.height.toDp()
+                    }
+                    val height = (screenHeight - 300.dp).coerceAtLeast(100.dp)
+
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(500.dp),
+                            .height(height),
                         contentAlignment = Alignment.Center
                     ) {
                         Text("Belum ada transaksi")


### PR DESCRIPTION
### What's new
- Added spacing at the end of the transaction list to ensure the last transaction is not obscured by the add Floating Action Button.
- Added no transactions yet to inform user that no transaction was ever made.

### Copilot's Summary
This pull request updates the `HomePage` composable to improve how empty transaction lists are displayed and refines spacing at the end of the transaction list. The main changes include adding a message for empty states and dynamically adjusting layout spacing.

**UI improvements for transaction list:**

* Added a conditional to display a centered message ("Belum ada transaksi") when the transaction list is empty, using the available screen height to center the message. This uses `LocalDensity` and `LocalWindowInfo` to calculate the appropriate height.
* When there are transactions, added a `Spacer` with a fixed height at the end of the list for improved padding.

**Imports for new UI logic:**

* Imported `LocalDensity`, `LocalWindowInfo`, and `coerceAtLeast` to support dynamic sizing and layout calculations for the empty state UI.

**Transaction list rendering logic:**

* Wrapped the transaction list rendering in a condition to only display items if there are transactions, otherwise show the empty state message.

Closes #8 