### PR TITLE
Enable Room database schema export and configure schema location

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,3 +108,7 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }
+
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}

--- a/app/schemas/com.felixjhonata.simplebudgetapp.data.room.database.SimpleBudgetAppDatabase/1.json
+++ b/app/schemas/com.felixjhonata.simplebudgetapp.data.room.database.SimpleBudgetAppDatabase/1.json
@@ -1,0 +1,94 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "97733ab65d63ed36b4f4401473751ce9",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `amount` REAL NOT NULL, `currency` TEXT NOT NULL, `date` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transactions_date_id",
+            "unique": false,
+            "columnNames": [
+              "date",
+              "id"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_transactions_date_id` ON `${TABLE_NAME}` (`date` DESC, `id` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "total_balance",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `totalBalance` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBalance",
+            "columnName": "totalBalance",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '97733ab65d63ed36b4f4401473751ce9')"
+    ]
+  }
+}

--- a/app/src/main/java/com/felixjhonata/simplebudgetapp/data/room/database/SimpleBudgetAppDatabase.kt
+++ b/app/src/main/java/com/felixjhonata/simplebudgetapp/data/room/database/SimpleBudgetAppDatabase.kt
@@ -9,8 +9,7 @@ import com.felixjhonata.simplebudgetapp.data.room.entity.Transaction
 
 @Database(
     entities = [Transaction::class, TotalBalance::class],
-    version = 1,
-    exportSchema = false
+    version = 1
 )
 abstract class SimpleBudgetAppDatabase: RoomDatabase() {
     abstract fun transactionDao(): TransactionDao


### PR DESCRIPTION
### What's New?
- Allowing exportScheme which auto generates the database scheme every time there is a migration in json format on `app/schemas/com.felixjhonata.simplebudgetapp.data.room.database.SimpleBudgetAppDatabase`

### Copilot's Summary
This pull request introduces Room database schema export functionality to the project and includes the initial schema file for version 1 of the database. The main changes involve enabling schema export in the build configuration, generating the schema JSON file, and updating the database definition.

**Room Schema Export and Database Schema**

* Build configuration:
  * Added a `ksp` block in `app/build.gradle.kts` to specify the Room schema export location, enabling automatic schema file generation.

* Database schema:
  * Added the initial Room schema file `app/schemas/com.felixjhonata.simplebudgetapp.data.room.database.SimpleBudgetAppDatabase/1.json`, capturing the structure of the `transactions` and `total_balance` tables, including fields, indices, and setup queries.

* Database definition:
  * Updated `SimpleBudgetAppDatabase.kt` to remove the `exportSchema = false` parameter, allowing Room to export the schema as configured.

Closes #10 